### PR TITLE
Initial go at enabling Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: cpp
+dist: trusty
+compiler: gcc
+script:
+    - git config --global color.ui false
+    - git config --global user.name "Fujitsu Network Communications"
+    - git config --global user.email "noreply@us.fujitsu.com"
+    - repo init -u https://github.com/FujitsuNetworkCommunications/fss2-manifest.git -b $MANIFEST_RELEASE
+    - repo sync
+    - rm -rf poky/meta-fss2-ppc
+    - ln -rs . poky/meta-fss2-ppc
+    - . ./poky/fss2-init-build-env -m t600
+    - bitbake core-image-minimal
+env:
+    global:
+        - MANIFEST_RELEASE="master"
+        - LANG="en_US.UTF-8"
+addons:
+    apt:
+        packages:
+            - gawk
+            - wget
+            - git-core
+            - diffstat
+            - unzip
+            - texinfo
+            - gcc-multilib
+            - build-essential
+            - chrpath
+            - libsdl1.2-dev
+            - phablet-tools

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FSS2Linux
 
-![N|FssLinux](http://www.fujitsu.com/global/resources/design/stylesheets/images/css_images/fujitsu/symbolmark.gif)
+![N|FssLinux](http://www.fujitsu.com/global/resources/design/stylesheets/images/css_images/fujitsu/symbolmark.gif) [![Build Status](https://travis-ci.org/FujitsuNetworkCommunications/meta-fss2-ppc.svg?branch=master)](https://travis-ci.org/FujitsuNetworkCommunications/meta-fss2-ppc)
 
 FSS2 Linux is based of poky 1.6, 3.x kernel and hosted on public github server maintained by Fujitsu organization. 
 Following describes workflow and steps to download FSS2Linux from public github and create a working build environment.

--- a/conf/machine/t600.conf
+++ b/conf/machine/t600.conf
@@ -1,8 +1,8 @@
 #@TYPE: Machine
 #@DESCRIPTION: Machine configuration for running T600 in 64-bit mode
 
-require ../../../meta-fsl-ppc/conf/machine/e6500-64b.inc
-require ../../../meta/conf/machine/include/soc-family.inc
+require conf/machine/e6500-64b.inc
+require conf/machine/include/soc-family.inc
 
 SOC_FAMILY = "t2080"
 # TODO: fix 32bit build of u-boot


### PR DESCRIPTION
This will initially fail because I need a dependent commit in meta-fss-linux's fss2-init-build-env but I wanted to get the review rolling.