### PR TITLE
Settings to fit withint Travis-CI constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ script:
     - rm -rf poky/meta-fss2-ppc
     - ln -rs . poky/meta-fss2-ppc
     - . ./poky/fss2-init-build-env -m t600
-    - bitbake core-image-minimal
+    - echo 'BB_DISKMON_DIRS = ""' >> conf/local.conf
+    - echo 'INHERIT += "rm_work"' >> conf/local.conf
+    - bitbake u-boot-mkimage-native
 env:
     global:
         - MANIFEST_RELEASE="master"


### PR DESCRIPTION
Running out of disk space during some runs so inherit
"rm_work" to delete more intermediate files.  Also
disable any bitbake checks for disk space so we can
go right to edge (little downside from crashing a VM or
container).

VM's get only 50 minutes and containers supposed to get 120
minutes but I'm seeing them killed after 50 minutes as well.
Our only current stable design choice is to compile subset
of recipes.  For now, that is to compile the u-boot-mkimage-native