### PR TITLE
Revert to 32bit rootfs and 64bit kernel mode

### DIFF
--- a/conf/machine/t600.conf
+++ b/conf/machine/t600.conf
@@ -1,7 +1,7 @@
 #@TYPE: Machine
 #@DESCRIPTION: Machine configuration for running T600 in 64-bit mode
 
-require conf/machine/e6500-64b.inc
+require conf/machine/e6500.inc
 require conf/machine/include/soc-family.inc
 
 SOC_FAMILY = "t2080"
@@ -16,4 +16,4 @@ SERIAL_CONSOLES = "115200;ttyS0 115200;ttyS1 115200;ttyEHV0"
 SERIAL_CONSOLES_CHECK = "${SERIAL_CONSOLES}"
 USE_VT = "0"
 
-BASELIB_powerpc64 = "lib"
+BUILD_64BIT_KERNEL = "1"


### PR DESCRIPTION
#5 

With this change confirmed  32bit rootfs and 64bit kernel image.
Example:

**Kernel build:** (64bit)
   /kernel/lib ((6717d19...) *)$ file *
    crc-itu-t.ko: ELF 64-bit MSB relocatable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), BuildID[sha1]=787c4536eb1f37a15a9b4686213500b51f4c4aa1, not stripped
    libcrc32c.ko: ELF 64-bit MSB relocatable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), BuildID[sha1]=54ecb9d314148bf627846062dc94fbb846e2009c, not stripped



**rootfs build**    (32bit)
 busybox.nosuid:      ELF 32-bit MSB executable, PowerPC or cisco 4500, version 1 (SYSV), dynamically linked (uses shared libs), for GNU/Linux 2.6.16, BuildID[sha1]=90e341f68f30270e8e6a87713f79fa41066c2044, with unknown capability 0x41000000 = 0xf676e75, with unknown capability 0x10000 = 0x70401, stripped

