### PR TITLE
remove packet's 4 bytes FCS comes from BCM5389

### DIFF
--- a/recipes-kernel/linux/files/t600/patches/0020-remove-packet-FCS-4-bytes-come-from-BCM5389.patch
+++ b/recipes-kernel/linux/files/t600/patches/0020-remove-packet-FCS-4-bytes-come-from-BCM5389.patch
@@ -1,0 +1,46 @@
+From 779f7fe28d40667692d0be89d03d044ed2b651e3 Mon Sep 17 00:00:00 2001
+From: linpower <linpower@edge-core.com>
+Date: Thu, 8 Nov 2018 18:08:21 +0800
+Subject: [PATCH] 1. remove packet FCS(4 bytes) come from BCM5389
+
+---
+ drivers/net/ethernet/freescale/dpa/dpaa_eth_sg.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/freescale/dpa/dpaa_eth_sg.c b/drivers/net/ethernet/freescale/dpa/dpaa_eth_sg.c
+index ecccc5e..c45f10a 100644
+--- a/drivers/net/ethernet/freescale/dpa/dpaa_eth_sg.c
++++ b/drivers/net/ethernet/freescale/dpa/dpaa_eth_sg.c
+@@ -144,7 +144,7 @@ static void dpa_remove_bcm_tag(struct sk_buff *skb, struct net_device *net_dev)
+        int length= skb->len;
+        int needed=sizeof(struct brcm_tag);
+        unsigned char new_data[1500]={0};
+-       int left_length=length-needed;
++       int left_length=length-needed-BRCM_FCS_SIZE;
+        int copy_length=0;
+ 
+        //memcpy(new_data,skb->data,12);
+@@ -152,8 +152,8 @@ static void dpa_remove_bcm_tag(struct sk_buff *skb, struct net_device *net_dev)
+        copy_length=12;
+        //memcpy(new_data+12,skb->data+12+sizeof(struct brcm_tag),length-12-sizeof(struct brcm_tag));
+        
+-        skb->len = length-needed;
+-        skb->tail-=needed;
++        skb->len = length-needed-BRCM_FCS_SIZE;
++        skb->tail = skb->tail-(needed+BRCM_FCS_SIZE);
+         while(left_length>0){
+             if(left_length>=1500){
+                 memcpy(new_data,skb->data+copy_length+sizeof(struct brcm_tag),1500);
+@@ -164,8 +164,8 @@ static void dpa_remove_bcm_tag(struct sk_buff *skb, struct net_device *net_dev)
+             else{
+                 memcpy(new_data,skb->data+copy_length+sizeof(struct brcm_tag),left_length);
+                 memcpy(skb->data+copy_length,new_data,left_length);
+-                left_length=0;
+                 copy_length=copy_length+left_length;
++                left_length=0;
+             }
+         }
+ #endif     
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-qoriq-sdk.bbappend
+++ b/recipes-kernel/linux/linux-qoriq-sdk.bbappend
@@ -31,6 +31,7 @@ SRC_URI_append_t600 += "file://${MACHINE}/patches/0001-Backport-PPC64-patch-to-l
                         file://${MACHINE}/patches/0017-modify-dpa-RX-TX-to-support-mtu-to-9000.patch               \
                         file://${MACHINE}/patches/0018-support-get-set-SFP-module-rate-autoneg-duplex-contr.patch  \
                         file://${MACHINE}/patches/0019-support-power-off-function.patch                            \
+                        file://${MACHINE}/patches/0020-remove-packet-FCS-4-bytes-come-from-BCM5389.patch           \
                        "
                        
 

--- a/recipes-kernel/linux/linux-qoriq_%.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_%.bbappend
@@ -50,6 +50,7 @@ SRC_URI_append_t600 += "file://${MACHINE}/patches/0001-Backport-PPC64-patch-to-l
                         file://${MACHINE}/patches/0017-modify-dpa-RX-TX-to-support-mtu-to-9000.patch               \
                         file://${MACHINE}/patches/0018-support-get-set-SFP-module-rate-autoneg-duplex-contr.patch  \
                         file://${MACHINE}/patches/0019-support-power-off-function.patch                            \
+                        file://${MACHINE}/patches/0020-remove-packet-FCS-4-bytes-come-from-BCM5389.patch           \
                        "
 
 KERNEL_DEFCONFIG  = "${WORKDIR}/kconfig/${MACHINE}_config"


### PR DESCRIPTION
ACCTON-240:upload CA and Certificate file to T600 fail via LCN00 interface.