### PR TITLE
workaround for hard-reset in R0A blade

### DIFF
--- a/recipes-kernel/linux/files/t600/patches/0023-workaround-for-hard-reset-in-R0A-blade.patch
+++ b/recipes-kernel/linux/files/t600/patches/0023-workaround-for-hard-reset-in-R0A-blade.patch
@@ -1,0 +1,40 @@
+From 30ec4912d5c51510571d93e899d3a424a32c4950 Mon Sep 17 00:00:00 2001
+From: aken_liu <aken_liu@accton.com.tw>
+Date: Wed, 21 Nov 2018 13:12:52 +0800
+Subject: [PATCH] workaround for hard-reset in R0A blade check the blade
+ version and then execute the reset function.  Hard reset: R0A: execute warm
+ reset. R0B: execute hard reset
+
+---
+ drivers/hwmon/accton_t600_cpld.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/drivers/hwmon/accton_t600_cpld.c b/drivers/hwmon/accton_t600_cpld.c
+index bac97d5..c636f63 100644
+--- a/drivers/hwmon/accton_t600_cpld.c
++++ b/drivers/hwmon/accton_t600_cpld.c
+@@ -301,6 +301,21 @@ static ssize_t reset(struct device *dev, struct device_attribute *da,
+         return -EINVAL;
+     }
+ 
++    /* check HW blade version.
++     * R0A: Not support Hard reset. We change to Warm reset to restart the system.
++     */
++    mutex_lock(&data->update_lock);
++    status = t600_cpld_read(client, BOARD_REV_REG);
++    if (unlikely(status < 0)) {
++        goto exit;
++    }
++    mutex_unlock(&data->update_lock);
++    if ((status & 0x7) == 0) /* R0A: 0x0, R0B: 0x1 */
++    {
++        if (reset == 1 )
++            reset = 2;   /* change HARD reset to WARM reset */
++    }
++
+     mutex_lock(&data->update_lock);
+     if (reset == 1) {
+         /* RESET_ALL when SW hard reset */
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-qoriq_%.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_%.bbappend
@@ -44,6 +44,7 @@ SRC_URI_append_t600 += "file://${MACHINE}/patches/0001-Backport-PPC64-patch-to-l
                         file://${MACHINE}/patches/0020-remove-packet-FCS-4-bytes-come-from-BCM5389.patch           \
                         file://${MACHINE}/patches/0021-add-protection-for-multi-processes-access-the-MDEC.patch    \
                         file://${MACHINE}/patches/0022-fix-2-sfp-bug.patch                                         \
+                        file://${MACHINE}/patches/0023-workaround-for-hard-reset-in-R0A-blade.patch                \
                        "
 
 KERNEL_DEFCONFIG  = "${WORKDIR}/kconfig/${MACHINE}_config"


### PR DESCRIPTION
check the blade version and then execute the reset function.
Hard reset:
 R0A: execute warm reset.
 R0B: execute hard reset

Accton-441: workaround the HARD reset in R0A blade