### PR TITLE
add code to find the pci parent resource.

### DIFF
--- a/recipes-kernel/linux/files/t600/patches/0024-add-code-to-find-the-pci-parent-resource.patch
+++ b/recipes-kernel/linux/files/t600/patches/0024-add-code-to-find-the-pci-parent-resource.patch
@@ -1,0 +1,27 @@
+From 259dc2387e599a1510e1cc98090b27ed6bee35e5 Mon Sep 17 00:00:00 2001
+From: aken_liu <aken_liu@accton.com.tw>
+Date: Mon, 3 Dec 2018 20:53:36 +0800
+Subject: [PATCH] add code to find the pci parent resource. ACCTON-313: PIU
+ cannot bring up when PIU is inserted during power on Blade.
+
+---
+ drivers/pci/setup-res.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/pci/setup-res.c b/drivers/pci/setup-res.c
+index 07f2edd..b7f3b0f 100644
+--- a/drivers/pci/setup-res.c
++++ b/drivers/pci/setup-res.c
+@@ -336,6 +336,9 @@ int pci_enable_resources(struct pci_dev *dev, int mask)
+ 				(!(r->flags & IORESOURCE_ROM_ENABLE)))
+ 			continue;
+ 
++		if (!r->parent)
++			r->parent = pci_find_parent_resource(dev, r);
++
+ 		if (!r->parent) {
+ 			dev_err(&dev->dev, "device not available "
+ 				"(can't reserve %pR)\n", r);
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-qoriq_%.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_%.bbappend
@@ -45,6 +45,7 @@ SRC_URI_append_t600 += "file://${MACHINE}/patches/0001-Backport-PPC64-patch-to-l
                         file://${MACHINE}/patches/0021-add-protection-for-multi-processes-access-the-MDEC.patch    \
                         file://${MACHINE}/patches/0022-fix-2-sfp-bug.patch                                         \
                         file://${MACHINE}/patches/0023-workaround-for-hard-reset-in-R0A-blade.patch                \
+                        file://${MACHINE}/patches/0024-add-code-to-find-the-pci-parent-resource.patch              \
                        "
 
 KERNEL_DEFCONFIG  = "${WORKDIR}/kconfig/${MACHINE}_config"


### PR DESCRIPTION
ACCTON-313: PIU cannot bring up when PIU is inserted during power on Blade.