### PR TITLE
ACCTON-538: Re: PM validity of NW port EQPT PM is sometimes false

### DIFF
--- a/recipes-kernel/linux/files/t600/patches/0028-ACCTON-538-Re-PM-validity-of-NW-port-EQPT-PM-is-some.patch
+++ b/recipes-kernel/linux/files/t600/patches/0028-ACCTON-538-Re-PM-validity-of-NW-port-EQPT-PM-is-some.patch
@@ -1,0 +1,392 @@
+From 18f2365da09cda5e9c7b128b40e991cbb944e749 Mon Sep 17 00:00:00 2001
+From: aken_liu <aken_liu@accton.com.tw>
+Date: Fri, 28 Dec 2018 16:49:37 +0800
+Subject: [PATCH] ACCTON-538: Re: PM validity of NW port EQPT PM is sometimes
+ false change the mutex lock range and move the global buffer to per-piu. 1.
+ add io_lock to protect each hardware access 2. remove original driver_lock
+ (protect per-pci bus) 3. add mido and qsfp locks per piu, user-space app
+ needs to use these mutex-lock to protect each operation progress. 4. move
+ global read buffer to per piu.
+
+---
+ drivers/misc/accton_t600_fj_mdec.c | 186 ++++++++++++++++++++++++++++++-------
+ 1 file changed, 151 insertions(+), 35 deletions(-)
+
+diff --git a/drivers/misc/accton_t600_fj_mdec.c b/drivers/misc/accton_t600_fj_mdec.c
+index d2173c1..f050610 100644
+--- a/drivers/misc/accton_t600_fj_mdec.c
++++ b/drivers/misc/accton_t600_fj_mdec.c
+@@ -143,19 +143,29 @@ enum fpga_sysfs_attributes
+     PORT5_EEPROM_0, PORT5_EEPROM_1, PORT5_EEPROM_2, PORT5_EEPROM_3, PORT6_EEPROM_0, PORT6_EEPROM_1, PORT6_EEPROM_2, PORT6_EEPROM_3, PORT7_EEPROM_0, PORT7_EEPROM_1, PORT7_EEPROM_2, PORT7_EEPROM_3,
+     PORT8_EEPROM_0, PORT8_EEPROM_1, PORT8_EEPROM_2, PORT8_EEPROM_3, PORT9_EEPROM_0, PORT9_EEPROM_1, PORT9_EEPROM_2, PORT9_EEPROM_3, PORT10_EEPROM_0, PORT10_EEPROM_1, PORT10_EEPROM_2, PORT10_EEPROM_3,
+     PORT11_EEPROM_0, PORT11_EEPROM_1, PORT11_EEPROM_2, PORT11_EEPROM_3, PORT12_EEPROM_0, PORT12_EEPROM_1, PORT12_EEPROM_2, PORT12_EEPROM_3, 
++    PIU1_DCO_MDIO_LOCK, PIU2_DCO_MDIO_LOCK, PIU1_QSFP_LOCK, PIU2_QSFP_LOCK,
+ };
+ 
+ struct fpga_device
+ {
+     char __iomem* hw_addr;
++#if 0
+     struct mutex driver_lock;
++#endif
+     struct mutex app_lock;
++    struct mutex app_piu1_qsfp_lock;
++    struct mutex app_piu2_qsfp_lock;
++    struct mutex app_piu1_dco_mdio_lock;
++    struct mutex app_piu2_dco_mdio_lock;
+     struct device dev;
++
++    /* for read data */
++    u32 mdec_read_result_data;
++    u16 mdio_read_result_data;
++    u8 qsfp_read_result_data;
+ };
+ 
+-static u16 mdio_read_result_data;
+-static u32 mdec_read_result_data;
+-static u8 qsfp_read_result_data;
++static struct mutex io_lock;
+ 
+ static void write_port_eeprom_one_byte(struct fpga_device* fpga_dev, u8 port, u8 pos, u8 value);
+ static void read_port_eeprom_data(struct fpga_device* fpga_dev, u8 port, u8 *buffer);
+@@ -164,14 +174,21 @@ static u8 read_port_eeprom_one_byte(struct fpga_device* fpga_dev, u8 port, u8 po
+ /* =================== local subprogram bodies =================== */
+ static u32 t600_fj_mdec_read32(void *addr)
+ {
+-	u32 value = ioread32(addr);
+-	return le32_to_cpu(value);
++    mutex_lock(&io_lock);
++    u32 value = ioread32(addr);
++    mutex_unlock(&io_lock);
++
++    return le32_to_cpu(value);
+ }
+ 
+ static void t600_fj_mdec_write32(u32 value, void *addr)
+ {
+-	u32 data = cpu_to_le32(value);
+-	iowrite32(data, addr);
++    u32 data = cpu_to_le32(value);
++
++    mutex_lock(&io_lock);
++    iowrite32(data, addr);
++    isync();
++    mutex_unlock(&io_lock);
+ }
+ 
+ /* =================== The Sysfs Interface Area [START] =================== */
+@@ -180,21 +197,23 @@ static ssize_t cpld_version_show(struct device* dev, struct device_attribute* at
+     struct fpga_device* fpga_dev = dev_get_drvdata(dev);
+     u32 value = 0x00000000;
+ 
+-    mutex_lock(&fpga_dev->driver_lock);
+     value = t600_fj_mdec_read32(fpga_dev->hw_addr + CPLD_VERSION);
+-    mutex_unlock(&fpga_dev->driver_lock);
+ 
+     return sprintf(buf, "0x%08X\n", value);
+ }
+ 
+ static ssize_t mdio_read_result(struct device* dev, struct device_attribute* attr, char* buf)
+ {
+-    return sprintf(buf, "0x%04X\n", mdio_read_result_data);
++    struct fpga_device* fpga_dev = dev_get_drvdata(dev);
++    
++    return sprintf(buf, "0x%04X\n", fpga_dev->mdio_read_result_data);
+ } 
+ 
+ static ssize_t mdec_read_result(struct device* dev, struct device_attribute* attr, char* buf)
+ {
+-    return sprintf(buf, "0x%08X\n", mdec_read_result_data);
++    struct fpga_device* fpga_dev = dev_get_drvdata(dev);
++    
++    return sprintf(buf, "0x%08X\n", fpga_dev->mdec_read_result_data);
+ }
+ 
+ static ssize_t read_mdec_eeprom(struct device* dev, struct device_attribute* attr, char* buf)
+@@ -205,7 +224,6 @@ static ssize_t read_mdec_eeprom(struct device* dev, struct device_attribute* att
+     int i = 0;
+     struct fpga_device* fpga_dev = dev_get_drvdata(dev);
+ 
+-    mutex_lock(&fpga_dev->driver_lock);    
+     mem_addr = fpga_dev->hw_addr + MDEC_EEPROM_ADDR;
+ 
+     for(i = 0; i < MDEC_EEPROM_SIZE; i+=4)
+@@ -217,14 +235,15 @@ static ssize_t read_mdec_eeprom(struct device* dev, struct device_attribute* att
+         eerpom_buf[i + 3] = value >> 0;
+     }
+ 
+-    mutex_unlock(&fpga_dev->driver_lock);
+     memcpy(buf, eerpom_buf, MDEC_EEPROM_SIZE);
+     return MDEC_EEPROM_SIZE;
+ }
+ 
+ static ssize_t qsfp_read_result(struct device* dev, struct device_attribute* attr, char* buf)
+ {
+-    return sprintf(buf, "0x%02X\n", qsfp_read_result_data);
++    struct fpga_device* fpga_dev = dev_get_drvdata(dev);
++    
++    return sprintf(buf, "0x%02X\n", fpga_dev->qsfp_read_result_data);
+ } 
+ 
+ /* Refer to sheet "21.Driver Control" of "T600_DHAL Specification_v1.6.xlsx" */
+@@ -234,7 +253,6 @@ static u32 mdio_access(struct device* dev, u32 mode, u32 page, u32 address, u32
+     u32 status;
+     int i = 0;
+ 
+-    mutex_lock(&fpga_dev->driver_lock);
+     // Check MDIO busy status
+     for(i = 0; i < MDIO_STATUS_CHK_RETRY_COUNT ; i++)
+     {
+@@ -266,7 +284,6 @@ static u32 mdio_access(struct device* dev, u32 mode, u32 page, u32 address, u32
+         }
+         else
+         {
+-            mutex_unlock(&fpga_dev->driver_lock);
+             return  - EINVAL;   
+         }    
+     }
+@@ -289,7 +306,6 @@ MDIO_READ_BEGIN:
+         }
+         else
+         {
+-            mutex_unlock(&fpga_dev->driver_lock);
+             return  - EINVAL;   
+         }
+         
+@@ -328,14 +344,13 @@ MDIO_READ_BEGIN:
+         // Read data
+         status = t600_fj_mdec_read32(fpga_dev->hw_addr + BMD_BUS_MDIO_RD_DT);
+     }
+-    
+-    mutex_unlock(&fpga_dev->driver_lock);
+ 
+     return status;
+ }
+ 
+ static ssize_t mdio_action_store(struct device* dev, struct device_attribute* attr, const char* buf, size_t count)
+ {
++    struct fpga_device* fpga_dev = dev_get_drvdata(dev);
+     u32 mode, page, address, data, status;
+ 
+     if(sscanf(buf, "0x%x 0x%x 0x%x 0x%x",&mode, &page, &address, &data) != 4)
+@@ -352,7 +367,7 @@ static ssize_t mdio_action_store(struct device* dev, struct device_attribute* at
+     status = mdio_access(dev, mode, page, address, data);
+     if((mode == MDIO_READ_MODE) && (status >= 0))
+     {
+-        mdio_read_result_data = status;
++        fpga_dev->mdio_read_result_data = status;
+     }
+ 
+     return count;
+@@ -375,9 +390,7 @@ static ssize_t mdec_action_store(struct device* dev, struct device_attribute* at
+         printk(KERN_WARNING "[ERR] mode ERR, mode range is 0X00000000 ~0x00000001 \r\n");
+         return  - EINVAL;
+     }
+-    
+-    mutex_lock(&fpga_dev->driver_lock);
+-        
++
+     // write
+     if(mode == MDEC_WRITE_MODE)
+     {
+@@ -385,11 +398,10 @@ static ssize_t mdec_action_store(struct device* dev, struct device_attribute* at
+     }
+     else
+     {
+-        // Read data
+-          mdec_read_result_data = t600_fj_mdec_read32(fpga_dev->hw_addr + address);
++        /* Read data */
++        fpga_dev->mdec_read_result_data = t600_fj_mdec_read32(fpga_dev->hw_addr + address);
+     }
+-    
+-    mutex_unlock(&fpga_dev->driver_lock);
++
+     return count;
+ }
+ 
+@@ -412,8 +424,6 @@ static ssize_t qsfp_action_store(struct device* dev, struct device_attribute* at
+     }
+     
+     port = port - 1; // application port are 1~12. kernel port are 0~11.
+-    mutex_lock(&fpga_dev->driver_lock);
+-
+ 
+     if(mode == I2C_WRITE_MODE)
+     {
+@@ -421,14 +431,12 @@ static ssize_t qsfp_action_store(struct device* dev, struct device_attribute* at
+     }
+     else
+     {
+-        qsfp_read_result_data = read_port_eeprom_one_byte(fpga_dev, port, address);
++        fpga_dev->qsfp_read_result_data = read_port_eeprom_one_byte(fpga_dev, port, address);
+ #if 0
+         printk(KERN_DEBUG "[DEBUG] READ - I2C_READ_DT = %02x\n", qsfp_read_result_data);
+ #endif
+     }
+ 
+-
+-    mutex_unlock(&fpga_dev->driver_lock);
+     return count;
+ }
+ 
+@@ -458,6 +466,103 @@ static ssize_t app_lock_store(struct device* dev, struct device_attribute* attr,
+ 
+     return count;
+ }
++
++static ssize_t app_qsfp_lock_store(struct device* dev, struct device_attribute* attr, const char* buf, size_t count)
++{
++    struct fpga_device* fpga_dev = dev_get_drvdata(dev);
++    struct sensor_device_attribute* dev_attr = to_sensor_dev_attr(attr);
++    u32 is_locked;
++
++    if(sscanf(buf, "%d", &is_locked) != 1)
++    {
++        return  - EINVAL;
++    }
++
++    if((is_locked < 0) || (is_locked > 1))
++    {
++        return  - EINVAL;
++    }
++
++    switch(dev_attr->index)
++    {
++
++        case PIU1_QSFP_LOCK:
++            if(is_locked)
++            {
++                mutex_lock(&fpga_dev->app_piu1_qsfp_lock);
++            }
++            else
++            {
++                mutex_unlock(&fpga_dev->app_piu1_qsfp_lock);
++            }
++            break;
++
++        case PIU2_QSFP_LOCK:
++            if(is_locked)
++            {
++                mutex_lock(&fpga_dev->app_piu2_qsfp_lock);
++            }
++            else
++            {
++                mutex_unlock(&fpga_dev->app_piu2_qsfp_lock);
++            }
++            break;
++        default:
++            printk (KERN_ERR "QSFP lock/unlock fail. \r\n");
++            break;
++    }
++
++    return count;
++}
++
++static ssize_t app_dco_mdio_lock_store(struct device* dev, struct device_attribute* attr, const char* buf, size_t count)
++{
++    struct fpga_device* fpga_dev = dev_get_drvdata(dev);
++    struct sensor_device_attribute* dev_attr = to_sensor_dev_attr(attr);
++    u32 is_locked;
++
++    if(sscanf(buf, "%d", &is_locked) != 1)
++    {
++        return  -EINVAL;
++    }
++
++    if((is_locked < 0) || (is_locked > 1))
++    {
++        return  -EINVAL;
++    }
++
++    switch(dev_attr->index)
++    {
++
++        case PIU1_DCO_MDIO_LOCK:
++            if(is_locked)
++            {
++                mutex_lock(&fpga_dev->app_piu1_dco_mdio_lock);
++            }
++            else
++            {
++                mutex_unlock(&fpga_dev->app_piu1_dco_mdio_lock);
++            }
++            break;
++
++        case PIU2_DCO_MDIO_LOCK:
++            if(is_locked)
++            {
++                mutex_lock(&fpga_dev->app_piu2_dco_mdio_lock);
++            }
++            else
++            {
++                mutex_unlock(&fpga_dev->app_piu2_dco_mdio_lock);
++            }
++            break;
++        default:
++            printk (KERN_ERR "DCO MDIO lock/unlock fail. \r\n");
++            break;
++    }
++
++    return count;
++}
++
+ static ssize_t temp_show(struct device* dev, struct device_attribute* attr, char* buf)
+ {
+     struct sensor_device_attribute* dev_attr = to_sensor_dev_attr(attr);
+@@ -480,7 +585,6 @@ static ssize_t read_port_eeprom(struct device* dev, struct device_attribute* att
+     struct fpga_device* fpga_dev = dev_get_drvdata(dev);
+     
+     memset(eerpom_buf, 0x00, QSFP_EEPROM_SIZE);
+-    mutex_lock(&fpga_dev->driver_lock);
+ 
+     switch(dev_attr->index)
+     {
+@@ -681,7 +785,6 @@ static ssize_t read_port_eeprom(struct device* dev, struct device_attribute* att
+              break;
+     }
+ 
+-    mutex_unlock(&fpga_dev->driver_lock);
+     memcpy(buf, eerpom_buf, QSFP_EEPROM_SIZE);
+     return QSFP_EEPROM_SIZE;
+ }
+@@ -828,6 +931,10 @@ static SENSOR_DEVICE_ATTR(mdec_eeprom, S_IRUGO, read_mdec_eeprom, NULL, MDEC_EEP
+ static SENSOR_DEVICE_ATTR(qsfp_offset, S_IWUSR, NULL, qsfp_action_store, QSFP_OFFSET_ATTR);
+ static SENSOR_DEVICE_ATTR(qsfp, S_IRUGO, qsfp_read_result, NULL, QSFP_ATTR);
+ static SENSOR_DEVICE_ATTR(app_locked, S_IWUSR, NULL, app_lock_store, 0);
++static SENSOR_DEVICE_ATTR(app_piu1_dco_mdio_locked, S_IWUSR, NULL, app_dco_mdio_lock_store, PIU1_DCO_MDIO_LOCK);
++static SENSOR_DEVICE_ATTR(app_piu2_dco_mdio_locked, S_IWUSR, NULL, app_dco_mdio_lock_store, PIU2_DCO_MDIO_LOCK);
++static SENSOR_DEVICE_ATTR(app_piu1_qsfp_locked, S_IWUSR, NULL, app_qsfp_lock_store, PIU1_QSFP_LOCK);
++static SENSOR_DEVICE_ATTR(app_piu2_qsfp_locked, S_IWUSR, NULL, app_qsfp_lock_store, PIU2_QSFP_LOCK);
+ 
+ #define DECLARE_PORT1_EEPROM_SENSOR_DEV_ATTR(index) \
+ static SENSOR_DEVICE_ATTR(port1_eeprom_##index, S_IRUGO, read_port_eeprom, NULL, PORT1_EEPROM_##index);
+@@ -923,7 +1030,9 @@ static struct attribute* sysfs_attributes[] =
+     DECLARE_PORT5_EEPROM_ATTR(0), DECLARE_PORT5_EEPROM_ATTR(1), DECLARE_PORT5_EEPROM_ATTR(2), DECLARE_PORT5_EEPROM_ATTR(3),DECLARE_PORT6_EEPROM_ATTR(0), DECLARE_PORT6_EEPROM_ATTR(1), DECLARE_PORT6_EEPROM_ATTR(2), DECLARE_PORT6_EEPROM_ATTR(3),DECLARE_PORT7_EEPROM_ATTR(0), DECLARE_PORT7_EEPROM_ATTR(1), DECLARE_PORT7_EEPROM_ATTR(2), DECLARE_PORT7_EEPROM_ATTR(3),
+     DECLARE_PORT8_EEPROM_ATTR(0), DECLARE_PORT8_EEPROM_ATTR(1), DECLARE_PORT8_EEPROM_ATTR(2), DECLARE_PORT8_EEPROM_ATTR(3),DECLARE_PORT9_EEPROM_ATTR(0), DECLARE_PORT9_EEPROM_ATTR(1), DECLARE_PORT9_EEPROM_ATTR(2), DECLARE_PORT9_EEPROM_ATTR(3),DECLARE_PORT10_EEPROM_ATTR(0), DECLARE_PORT10_EEPROM_ATTR(1), DECLARE_PORT10_EEPROM_ATTR(2), DECLARE_PORT10_EEPROM_ATTR(3),
+     DECLARE_PORT11_EEPROM_ATTR(0), DECLARE_PORT11_EEPROM_ATTR(1), DECLARE_PORT11_EEPROM_ATTR(2), DECLARE_PORT11_EEPROM_ATTR(3),DECLARE_PORT12_EEPROM_ATTR(0), DECLARE_PORT12_EEPROM_ATTR(1), DECLARE_PORT12_EEPROM_ATTR(2), DECLARE_PORT12_EEPROM_ATTR(3),
+-    &sensor_dev_attr_app_locked.dev_attr.attr,
++    &sensor_dev_attr_app_locked.dev_attr.attr, 
++    &sensor_dev_attr_app_piu1_dco_mdio_locked.dev_attr.attr, &sensor_dev_attr_app_piu2_dco_mdio_locked.dev_attr.attr, 
++    &sensor_dev_attr_app_piu1_qsfp_locked.dev_attr.attr, &sensor_dev_attr_app_piu2_qsfp_locked.dev_attr.attr,
+     NULL,
+ };
+ 
+@@ -970,8 +1079,15 @@ static int accton_fpga_probe(struct pci_dev* pdev, const struct pci_device_id* d
+         dev_err(&pdev->dev, "unable to allocate device memory.\r\n");
+         goto err_out_int;
+     }
++#if 0
+     mutex_init(&fpga_dev->driver_lock);
++#endif
+     mutex_init(&fpga_dev->app_lock);
++    mutex_init(&fpga_dev->app_piu1_dco_mdio_lock);
++    mutex_init(&fpga_dev->app_piu2_dco_mdio_lock);
++    mutex_init(&fpga_dev->app_piu1_qsfp_lock);
++    mutex_init(&fpga_dev->app_piu2_qsfp_lock);
++    mutex_init(&io_lock);
+ 
+     pci_set_drvdata(pdev, fpga_dev);
+ 
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-qoriq_%.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_%.bbappend
@@ -49,6 +49,7 @@ SRC_URI_append_t600 += "file://${MACHINE}/patches/0001-Backport-PPC64-patch-to-l
                         file://${MACHINE}/patches/0025-remove-retry-messages-while-retrying-i2c-interface.patch    \
                         file://${MACHINE}/patches/0026-support-LM75-on-the-PIU.patch                               \
                         file://${MACHINE}/patches/0027-ACCTON-550-change-udelay-to-usleep-for-improving-the.patch  \
+                        file://${MACHINE}/patches/0028-ACCTON-538-Re-PM-validity-of-NW-port-EQPT-PM-is-some.patch  \
                        "
 
 KERNEL_DEFCONFIG  = "${WORKDIR}/kconfig/${MACHINE}_config"


### PR DESCRIPTION
change the mutex lock range and move the global buffer to per-piu.
1. add io_lock to protect each hardware access
2. remove original driver_lock (protect per-pci bus)
3. add mido and qsfp locks per piu, user-space app needs to use these mutex-lock to protect each operation progress.
4. move global read buffer to per piu.