### PR TITLE
support psu status input byte

### DIFF
--- a/recipes-kernel/linux/files/t600/patches/0031-support-psu-status-input-byte.patch
+++ b/recipes-kernel/linux/files/t600/patches/0031-support-psu-status-input-byte.patch
@@ -1,0 +1,93 @@
+From 2ec217cdd68897c297be80ed7272d8287170030f Mon Sep 17 00:00:00 2001
+From: aken_liu <aken_liu@accton.com.tw>
+Date: Wed, 9 Jan 2019 10:24:49 +0800
+Subject: [PATCH] support psu status-input byte
+
+---
+ drivers/hwmon/pmbus/dps_800ab_16_d.c | 29 ++++++++++++++++++++++++++++-
+ 1 file changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/hwmon/pmbus/dps_800ab_16_d.c b/drivers/hwmon/pmbus/dps_800ab_16_d.c
+index 3272bd2..bc600ad 100644
+--- a/drivers/hwmon/pmbus/dps_800ab_16_d.c
++++ b/drivers/hwmon/pmbus/dps_800ab_16_d.c
+@@ -49,13 +49,14 @@ struct dps_800ab_16_d_data {
+ 
+ 	/* Registers value */
+ 	u8	vout_mode;
++	u8	status_input;
+ 	u16	v_in;
+ 	u16	v_out;
+ 	u16	i_in;
+ 	u16	i_out;
+ 	u16	p_in;
+ 	u16	p_out;
+-	u16 status_word;
++	u16	status_word;
+ 	u16	temp_input[2];
+ 	u8	fan_fault;
+ 	u16	fan_duty_cycle[2];
+@@ -98,6 +99,7 @@ enum dps_800ab_16_d_sysfs_attributes {
+ 	PSU_MFR_MODEL,
+ 	PSU_MFR_SERIAL,
+ 	PSU_STATUS,
++	PSU_STATUS_INPUT,
+ };
+ 
+ static int two_complement_to_int(u16 data, u8 valid_bit, int mask)
+@@ -245,6 +247,28 @@ static ssize_t show_word(struct device *dev, struct device_attribute *dev_attr,
+     return sprintf(buf, "%d\n", data->status_word);
+ }
+ 
++static ssize_t show_byte(struct device *dev, struct device_attribute *dev_attr,
++                                 char *buf)
++{
++    struct sensor_device_attribute *attr = to_sensor_dev_attr(dev_attr);
++    struct dps_800ab_16_d_data *data = dps_800ab_16_d_update_device(dev);
++    u8     status = 0;
++
++    if (!data->valid) {
++        return 0;
++    }
++
++    switch (attr->index) {
++        case PSU_STATUS_INPUT:
++            status = data->status_input;
++            break;
++        default:
++            break;
++    }
++
++    return sprintf(buf, "%d\n", status);
++}
++
+ static int dps_800ab_16_d_read_byte(struct i2c_client *client, u8 reg)
+ {
+ 	return i2c_smbus_read_byte_data(client, reg);
+@@ -307,6 +331,7 @@ static struct dps_800ab_16_d_data *dps_800ab_16_d_update_device( \
+ 		u8 command;
+ 		struct reg_data_byte regs_byte[] = {
+ 				{0x20, &data->vout_mode},
++				{0x7c, &data->status_input},
+ 				{0x81, &data->fan_fault}
+ 		};
+ 		struct reg_data_word regs_word[] = {
+@@ -395,6 +420,7 @@ static SENSOR_DEVICE_ATTR(psu_fan1_fault,     S_IRUGO, for_fan_fault, 	NULL, PSU
+ static SENSOR_DEVICE_ATTR(psu_mfr_model,      S_IRUGO, for_ascii,       NULL, PSU_MFR_MODEL);
+ static SENSOR_DEVICE_ATTR(psu_mfr_serial,     S_IRUGO, for_ascii,       NULL, PSU_MFR_SERIAL);
+ static SENSOR_DEVICE_ATTR(psu_status,         S_IRUGO, show_word,       NULL, PSU_STATUS);
++static SENSOR_DEVICE_ATTR(psu_status_input,   S_IRUGO, show_byte,       NULL, PSU_STATUS_INPUT);
+ 
+ static struct attribute *dps_800ab_16_d_attributes[] = {
+ 	&sensor_dev_attr_psu_v_in.dev_attr.attr,
+@@ -410,6 +436,7 @@ static struct attribute *dps_800ab_16_d_attributes[] = {
+ 	&sensor_dev_attr_psu_mfr_model.dev_attr.attr,
+ 	&sensor_dev_attr_psu_mfr_serial.dev_attr.attr,
+ 	&sensor_dev_attr_psu_status.dev_attr.attr,
++	&sensor_dev_attr_psu_status_input.dev_attr.attr,
+ 	NULL
+ };
+ 
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-qoriq_%.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_%.bbappend
@@ -52,6 +52,7 @@ SRC_URI_append_t600 += "file://${MACHINE}/patches/0001-Backport-PPC64-patch-to-l
                         file://${MACHINE}/patches/0028-ACCTON-538-Re-PM-validity-of-NW-port-EQPT-PM-is-some.patch  \
                         file://${MACHINE}/patches/0029-ACCTON-379-Blade-cannot-start-up-by-Time-has-been-ch.patch  \
                         file://${MACHINE}/patches/0030-ACCTON-537-OC-Unable-generate-about-PSU-failure-alar.patch  \
+                        file://${MACHINE}/patches/0031-support-psu-status-input-byte.patch                         \
                        "
 
 KERNEL_DEFCONFIG  = "${WORKDIR}/kconfig/${MACHINE}_config"


### PR DESCRIPTION
(same issue: ACCTON-537: [OC] Unable generate about PSU failure alarm when plug two AC power and other one without power input.)