### PR TITLE
ACCTON-706: LED control does not work on FAN slot

### DIFF
--- a/recipes-kernel/linux/files/t600/patches/0035-ACCTON-706-LED-control-does-not-work-on-FAN-slot.patch
+++ b/recipes-kernel/linux/files/t600/patches/0035-ACCTON-706-LED-control-does-not-work-on-FAN-slot.patch
@@ -1,0 +1,166 @@
+From fdb304b35eafb8a142117b78036e7ab2d6fb82bb Mon Sep 17 00:00:00 2001
+From: aken_liu <aken_liu@accton.com.tw>
+Date: Thu, 24 Jan 2019 17:57:51 +0800
+Subject: [PATCH] ACCTON-706: LED control does not work on FAN slot Add
+ fanX_led_blink attribute to control LED.
+
+---
+ drivers/hwmon/accton_t600_fan.c | 79 +++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 77 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/hwmon/accton_t600_fan.c b/drivers/hwmon/accton_t600_fan.c
+index c50f003..2eef392 100644
+--- a/drivers/hwmon/accton_t600_fan.c
++++ b/drivers/hwmon/accton_t600_fan.c
+@@ -53,6 +53,9 @@ enum fan_duty_cycle {
+ #define FAN_SPEED_CTRL_INTERVAL	3000
+ #define THERMAL_SENSOR_DATA_LEN 6
+ 
++#define FAN_REG_LED             16
++#define FAN_REG_LED_BLINK       17
++
+ enum thermal_id
+ {
+     THERMAL_LM75_11_48,
+@@ -164,6 +167,7 @@ static ssize_t set_duty_cycle(struct device *dev, struct device_attribute *da,
+ 
+ static ssize_t set_fan_enable(struct device *dev, struct device_attribute *da,
+             const char *buf, size_t count);
++static ssize_t t600_fan_blink(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
+ static ssize_t set_fan_watchdog(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
+ static ssize_t raw_access(struct device *dev, struct device_attribute *da,
+             const char *buf, size_t count);             
+@@ -185,7 +189,9 @@ static const u8 fan_reg[] = {
+     0x25,      /* rear fan 4 speed(rpm) */
+     0x26,      /* rear fan 5 speed(rpm) */
+     0x30,      /* fan power enable */
+-    0x33       /* fan watchdog */
++    0x33,      /* fan watchdog */
++    0x42,      /* fan LED */
++    0x44,      /* fan LED blinking */
+ };
+ 
+ /* Each client has this additional data */
+@@ -211,6 +217,7 @@ struct t600_fan_data {
+ #define FAN_1_INPUT_ATTR_ID(index)      FAN##index##_1_INPUT
+ #define FAN_2_INPUT_ATTR_ID(index)      FAN##index##_2_INPUT
+ #define FAN_DIRECTION_ATTR_ID(index)    FAN##index##_DIRECTION
++#define FAN_LED_BLINK_ATTR_ID(index)    FAN##index##_LED_BLINK
+ 
+ enum fan_id {
+     FAN1_ID,
+@@ -258,6 +265,11 @@ enum sysfs_fan_attributes {
+     FAN_DIRECTION_ATTR_ID(3),
+     FAN_DIRECTION_ATTR_ID(4),
+     FAN_DIRECTION_ATTR_ID(5),
++    FAN_LED_BLINK_ATTR_ID(1),
++    FAN_LED_BLINK_ATTR_ID(2),
++    FAN_LED_BLINK_ATTR_ID(3),
++    FAN_LED_BLINK_ATTR_ID(4),
++    FAN_LED_BLINK_ATTR_ID(5),
+ #if (ENABLE_FAN_CTRL_ROUTINE == 1)
+     FAN_DISABLE_FANCTRL,
+     FAN_PIU1_DSP1_THERMAL,
+@@ -314,6 +326,10 @@ static SENSOR_DEVICE_ATTR(raw_access, S_IWUSR | S_IRUGO, NULL, raw_access, ACCES
+     static SENSOR_DEVICE_ATTR(fan##index##_enable, S_IWUSR | S_IRUGO, fan_show_value, set_fan_enable, FAN##index##_ENABLE)
+ #define DECLARE_FAN_ENABLE_ATTR(index)    &sensor_dev_attr_fan##index##_enable.dev_attr.attr
+ 
++#define DECLARE_FAN_LED_BLINK_SENSOR_DEV_ATTR(index) \
++    static SENSOR_DEVICE_ATTR(fan##index##_led_blink, S_IWUSR, NULL, t600_fan_blink, FAN##index##_LED_BLINK)
++#define DECLARE_FAN_LED_BLINK_ATTR(index)    &sensor_dev_attr_fan##index##_led_blink.dev_attr.attr
++
+ 
+ /* 5 fan fault attributes in this platform */
+ DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(1);
+@@ -347,6 +363,12 @@ DECLARE_FAN_ENABLE_SENSOR_DEV_ATTR(2);
+ DECLARE_FAN_ENABLE_SENSOR_DEV_ATTR(3);
+ DECLARE_FAN_ENABLE_SENSOR_DEV_ATTR(4);
+ DECLARE_FAN_ENABLE_SENSOR_DEV_ATTR(5);
++/* 5 fan brightness attributes in this platform */
++DECLARE_FAN_LED_BLINK_SENSOR_DEV_ATTR(1);
++DECLARE_FAN_LED_BLINK_SENSOR_DEV_ATTR(2);
++DECLARE_FAN_LED_BLINK_SENSOR_DEV_ATTR(3);
++DECLARE_FAN_LED_BLINK_SENSOR_DEV_ATTR(4);
++DECLARE_FAN_LED_BLINK_SENSOR_DEV_ATTR(5);
+ 
+ static struct attribute *t600_fan_attributes[] = {
+     &sensor_dev_attr_cpld_version.dev_attr.attr,
+@@ -379,6 +401,11 @@ static struct attribute *t600_fan_attributes[] = {
+     DECLARE_FAN_PRESENT_ATTR(3),
+     DECLARE_FAN_PRESENT_ATTR(4),
+     DECLARE_FAN_PRESENT_ATTR(5),
++    DECLARE_FAN_LED_BLINK_ATTR(1),
++    DECLARE_FAN_LED_BLINK_ATTR(2),
++    DECLARE_FAN_LED_BLINK_ATTR(3),
++    DECLARE_FAN_LED_BLINK_ATTR(4),
++    DECLARE_FAN_LED_BLINK_ATTR(5),
+ #if (ENABLE_FAN_CTRL_ROUTINE == 1)
+     &sensor_dev_attr_fan_disable_fanctrl.dev_attr.attr,
+     &sensor_dev_attr_fan_piu1_dsp1_thermal.dev_attr.attr,
+@@ -542,7 +569,7 @@ static ssize_t set_fan_enable(struct device *dev, struct device_attribute *da, c
+     int error, value, index;
+     u8 reg = 0, mask = 0;
+     int regval;
+-        struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
++    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+     struct i2c_client *client = to_i2c_client(dev);
+     struct t600_fan_data *data = i2c_get_clientdata(client);
+ 
+@@ -589,6 +616,54 @@ static ssize_t set_fan_watchdog(struct device *dev, struct device_attribute *da,
+     return count;
+ }
+ 
++static ssize_t t600_fan_blink(struct device *dev, struct device_attribute *da, const char *buf, size_t count) 
++{
++    int error, value, status, ret;
++    u8 reg = 0, mask = 0;
++    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
++    struct i2c_client *client = to_i2c_client(dev);
++    struct t600_fan_data *data = i2c_get_clientdata(client);
++
++    error = kstrtoint(buf, 10, &value);
++    if (error) {
++        return error;
++    }
++
++    if (value < 0 || value > 1) {
++        return -EINVAL;
++    }
++
++    mask = 1 << (attr->index - FAN_LED_BLINK_ATTR_ID(1) + 3);
++    if (1 == value) {
++        mutex_lock(&data->update_lock);
++        reg = fan_reg[FAN_REG_LED];
++        status = t600_fan_read_value(client, reg);
++        status |= mask;
++        ret = t600_fan_write_value(client, reg, status);
++
++        reg = fan_reg[FAN_REG_LED_BLINK];
++        status = t600_fan_read_value(client, reg);
++        status |= mask;
++        ret = t600_fan_write_value(client, reg, status);
++        mutex_unlock(&data->update_lock);
++    }
++    else {
++        mutex_lock(&data->update_lock);
++        reg = fan_reg[FAN_REG_LED];
++        status = t600_fan_read_value(client, reg);
++        status &= ~mask;
++        ret = t600_fan_write_value(client, reg, status);
++
++        reg = fan_reg[FAN_REG_LED_BLINK];
++        status = t600_fan_read_value(client, reg);
++        status &= ~mask;
++        ret = t600_fan_write_value(client, reg, status);
++        mutex_unlock(&data->update_lock);
++    }
++
++    return count;
++}
++
+ static ssize_t raw_access(struct device *dev, struct device_attribute *da,
+             const char *buf, size_t count)
+ {
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-qoriq_%.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_%.bbappend
@@ -56,6 +56,7 @@ SRC_URI_append_t600 += "file://${MACHINE}/patches/0001-Backport-PPC64-patch-to-l
                         file://${MACHINE}/patches/0032-ACCTON-683-Remove-Insert-PIU-slot1-or-slot2-doesn-t-.patch  \
                         file://${MACHINE}/patches/0033-support_otp_shutdown_blade.patch                            \
                         file://${MACHINE}/patches/0034-ACCTON-715-IQT-6-PIU-equipmentRemoved-happened-after.patch  \
+                        file://${MACHINE}/patches/0035-ACCTON-706-LED-control-does-not-work-on-FAN-slot.patch      \
                        "
 
 KERNEL_DEFCONFIG  = "${WORKDIR}/kconfig/${MACHINE}_config"


### PR DESCRIPTION
Add fanX_led_blink attribute to control LED.