### PR TITLE
ACCTON-727-continued-fix-previous-err-handl-patch_

### DIFF
--- a/recipes-kernel/linux/files/t600/patches/0040-ACCTON-727-fix_incomplete_patch-dpa-tx-err-hand-.patch
+++ b/recipes-kernel/linux/files/t600/patches/0040-ACCTON-727-fix_incomplete_patch-dpa-tx-err-hand-.patch
@@ -1,0 +1,25 @@
+--- a/drivers/net/ethernet/freescale/dpa/dpaa_eth_sg.c	2019-02-15 15:42:06.160142123 -0600
++++ b/drivers/net/ethernet/freescale/dpa/dpaa_eth_sg.c	2019-02-15 15:45:34.530570529 -0600
+@@ -1287,6 +1287,11 @@
+ 	int *countptr, offset = 0;
+ 
+         struct sk_buff *new_skb=NULL;
++
++	priv = netdev_priv(net_dev);
++	/* Non-migratable context, safe to use __this_cpu_ptr */
++	percpu_priv = __this_cpu_ptr(priv->percpu_priv);
++	percpu_stats = &percpu_priv->stats;
+   
+ /* modify by peter, for BCM management tag*/
+ 	/*printk("(%s:%d) net_dev->name:%s, packet len:%d,skb->no_fcs:%d, csum:%08x, ip_summ:%d\n",__FUNCTION__,__LINE__,net_dev->name,skb->len,skb->no_fcs,skb->csum,skb->ip_summed);*/
+@@ -1328,10 +1333,6 @@
+ 		/* won't update any Tx stats */
+ 		return NETDEV_TX_OK;
+ #endif
+-	priv = netdev_priv(net_dev);
+-	/* Non-migratable context, safe to use __this_cpu_ptr */
+-	percpu_priv = __this_cpu_ptr(priv->percpu_priv);
+-	percpu_stats = &percpu_priv->stats;
+ 	countptr = __this_cpu_ptr(priv->dpa_bp->percpu_count);
+ 
+ 	clear_fd(&fd);

--- a/recipes-kernel/linux/linux-qoriq_%.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_%.bbappend
@@ -61,6 +61,7 @@ SRC_URI_append_t600 += "file://${MACHINE}/patches/0001-Backport-PPC64-patch-to-l
                         file://${MACHINE}/patches/0037-Because-TCP-need-use-packet-buffer-for-retransmis.patch     \
                         file://${MACHINE}/patches/0038-fix-some-minor-issues.patch                                 \
                         file://${MACHINE}/patches/0039-ACCTON-727-continued-fix-dpa-tx-err-hand.patch              \
+                        file://${MACHINE}/patches/0040-ACCTON-727-fix_incomplete_patch-dpa-tx-err-hand-.patch      \
                        "
 
 KERNEL_DEFCONFIG  = "${WORKDIR}/kconfig/${MACHINE}_config"
@@ -100,4 +101,4 @@ do_deploy_append () {
    done
 }
 
-PR := "${PR}.2"
+PR := "${PR}.3"


### PR DESCRIPTION
Fix problem with previous patch .   Move initialization of  percpu stats above first usage.