### PR TITLE
ACCTON-996: Too many open files in system

### DIFF
--- a/recipes-kernel/linux/files/t600/patches/0043-ACCTON-996-Too-many-open-files-in-system.patch
+++ b/recipes-kernel/linux/files/t600/patches/0043-ACCTON-996-Too-many-open-files-in-system.patch
@@ -1,0 +1,28 @@
+From acca97d286fadfd2801a4aad55021f9881f87af3 Mon Sep 17 00:00:00 2001
+From: aken_liu <aken_liu@accton.com.tw>
+Date: Mon, 10 Jun 2019 14:42:58 +0800
+Subject: [PATCH] ACCTON-996: Too many open files in system Root Casue: After
+ fan controller opens and reads the thermal sensor's sysfs, we do not close
+ it. The fan controller is a periodic task, it casues there are a lot of
+ opened files in the linux system. Solution: After reading the data, we shall
+ close the file.
+
+---
+ drivers/hwmon/accton_t600_fan.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/hwmon/accton_t600_fan.c b/drivers/hwmon/accton_t600_fan.c
+index 2eef392..8c4046d 100644
+--- a/drivers/hwmon/accton_t600_fan.c
++++ b/drivers/hwmon/accton_t600_fan.c
+@@ -903,6 +903,7 @@ static int read_file_contents(char *path, char *buf, long data_len, struct devic
+ 		}
+ 
+ 		kernel_read(fp, 0, buf, data_len);
++                filp_close(fp, NULL);
+ 		break;
+ 	}
+ 
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-qoriq_3.12.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_3.12.bbappend
@@ -68,6 +68,7 @@ SRC_URI_append_t600 += "file://patches/0001-Updated-BR_GROUPFWD_RESTRICTED-to-0x
                         file://${MACHINE}/patches/0041-Add-PIU-scan-mutex.-Application-must-use-this-mutex-.patch  \
                         file://${MACHINE}/patches/0042-ACCTON-858-Main-signal-is-down-after-PIU-reseat.patch       \
                         file://patches/0001-powerpc-discard-.exit.data-at-runtime.patch \
+                        file://${MACHINE}/patches/0043-ACCTON-996-Too-many-open-files-in-system.patch \
                        "
 
 KERNEL_DEVICETREE = "${MACHINE}.dtb"

--- a/recipes-kernel/linux/linux-qoriq_4.1.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_4.1.bbappend
@@ -47,6 +47,7 @@ SRC_URI_append_t600 += "file://${MACHINE}/patches/0002-4.1-Chage-to-fit-T600-NOR
                         file://${MACHINE}/patches/0038-4.1-fix-some-minor-issues.patch                             \
                         file://${MACHINE}/patches/0039-4.1-ACCTON-727-continued-fix-dpa-tx-err-hand.patch          \
                         file://${MACHINE}/patches/0040-4.1-ACCTON-727-fix_incomplete_patch-dpa-tx-err-hand.patch   \
+                        file://${MACHINE}/patches/0043-ACCTON-996-Too-many-open-files-in-system.patch \
                        "
 
 KERNEL_DEFCONFIG  = "${WORKDIR}/${MACHINE}/kconfig/${MACHINE}_config"


### PR DESCRIPTION
 Root Casue: After fan controller opens and reads the thermal sensor's sysfs, we do not close
             it. The fan controller is a periodic task, it casues there are a lot of opened files
             in the linux system.
 Solution: After reading the data, we shall close the file.