### PR TITLE
Fix include error. linux-3.12 t600.dts had linux-4.1 file included

### DIFF
--- a/recipes-kernel/linux/files/t600/dts/t600.dts
+++ b/recipes-kernel/linux/files/t600/dts/t600.dts
@@ -33,7 +33,6 @@
  */
 
 /include/ "fsl/t208xsi-pre.dtsi"
-/include/ "fsl/t208xrdb.dtsi"
 /include/ "t600.dtsi"
 
 / {

--- a/recipes-kernel/linux/linux-qoriq_3.12.bb
+++ b/recipes-kernel/linux/linux-qoriq_3.12.bb
@@ -11,7 +11,7 @@ SRC_URI = "git://git.freescale.com/ppc/sdk/linux.git;nobranch=1 \
 "
 SRCREV = "6619b8b55796cdf0cec04b66a71288edd3057229"
 PV = "3.12"
-PR = "${INC_PR}.1"
+PR = "${INC_PR}.2"
 
 SCMVERSION ?= "y"
 


### PR DESCRIPTION
Fix include error. linux-3.12 t600.dts had linux-4.1 file included