### PR TITLE
[ACCTON-1013] Sometimes FAN speed change to MAX

### DIFF
--- a/recipes-kernel/linux/files/t600/patches/0044-Fan-speed-changes-to-max-automatically.patch
+++ b/recipes-kernel/linux/files/t600/patches/0044-Fan-speed-changes-to-max-automatically.patch
@@ -1,0 +1,129 @@
+From fbe9a4e528a45b5423f7e4bc0cd7a5c98762afa9 Mon Sep 17 00:00:00 2001
+From: aken_liu <aken_liu@accton.com.tw>
+Date: Wed, 24 Jul 2019 16:51:20 +0800
+Subject: [PATCH] Fan speed changes to max automatically. Root casue: FAN
+ driver uses Linux string conversion API to get temperature string. When this
+ API return error, the temperature value is wrong, it casues FAN driver sets
+ FAN to full speed.
+
+Solution:
+1. Buffer clear before read temperature, otherwise it will keep last value and cause kstrtoint parser error.
+2. separate the check flag, valid and temp-is-valid, for FAN updater and temperature updater.
+---
+ drivers/hwmon/accton_t600_fan.c | 49 +++++++++++++++++++++++++++--------------
+ 1 file changed, 32 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/hwmon/accton_t600_fan.c b/drivers/hwmon/accton_t600_fan.c
+index 8c4046d..5502329 100644
+--- a/drivers/hwmon/accton_t600_fan.c
++++ b/drivers/hwmon/accton_t600_fan.c
+@@ -58,21 +58,21 @@ enum fan_duty_cycle {
+ 
+ enum thermal_id
+ {
+-    THERMAL_LM75_11_48,
+-    THERMAL_LM75_11_49,
+-    THERMAL_LM75_11_4a,
+-    THERMAL_LM75_11_4b,
+-    THERMAL_LM75_11_4c,
+-    THERMAL_LM75_20_49,
+-    THERMAL_LM75_21_49,
+-    THERMAL_LM75_31_48,
++    THERMAL_LM75_T1,
++    THERMAL_LM75_T2,
++    THERMAL_LM75_T3,
++    THERMAL_LM75_T4,
++    THERMAL_LM75_T5,
++    THERMAL_LM75_T6,
++    THERMAL_LM75_T7,
++    THERMAL_LM75_T8,
+     NUM_OF_THERMAL_SENSOR
+ };
+ 
+ #if 1 /* Roy Chuang Mark Begin 2018/9/5, reason: */
+ char *thermal_sensor_path[NUM_OF_THERMAL_SENSOR] = {
+-"/sys/bus/i2c/devices/20-0049/temp1_input",
+-"/sys/bus/i2c/devices/21-0049/temp1_input",
++"/sys/bus/i2c/devices/20-0049/temp1_input", /* RNR sensor from PIU1 */
++"/sys/bus/i2c/devices/21-0049/temp1_input", /* RNR sensor from PIU2 */
+ "/sys/bus/i2c/devices/31-0048/temp1_input",
+ "none_temp1_input",    /* skip */
+ "none_temp1_input",    /* skip */
+@@ -199,6 +199,7 @@ struct t600_fan_data {
+     struct device   *hwmon_dev;
+     struct mutex     update_lock;
+     char        valid;         /* != 0 if registers are valid */
++    char        temp_is_valid; /* != 0 if temperature are valid */
+     unsigned long   last_updated;   /* In jiffies */
+     u8      reg_val[ARRAY_SIZE(fan_reg)]; /* Register value */
+ 
+@@ -903,7 +904,7 @@ static int read_file_contents(char *path, char *buf, long data_len, struct devic
+ 		}
+ 
+ 		kernel_read(fp, 0, buf, data_len);
+-                filp_close(fp, NULL);
++		filp_close(fp, NULL);
+ 		break;
+ 	}
+ 
+@@ -917,7 +918,7 @@ static struct t600_fan_data *t600_fan_update_temperature(struct device *dev)
+ 	int i = 0;
+ 	char temp[NUM_OF_THERMAL_SENSOR][THERMAL_SENSOR_DATA_LEN+1];
+ 
+-	data->valid = 0;
++	data->temp_is_valid = 0;
+ 
+ 	/* Update temperature
+ 	 */
+@@ -926,21 +927,35 @@ static struct t600_fan_data *t600_fan_update_temperature(struct device *dev)
+ 				continue;
+ 		}
+ 
++		memset(temp[i], 0, sizeof(temp[i]));
+ 		if (read_file_contents(thermal_sensor_path[i], temp[i], sizeof(temp[i]), &client->dev) == 0) {
+ 			temp[i][sizeof(temp[i])-1] = '\0';
+ 
+ 			if (kstrtoint(temp[i], 10, &data->temp_input[i]) != 0) {
+-				dev_dbg(&client->dev, "Failed to convert temperature read from (%s)\n", thermal_sensor_path[i]);
+-				goto exit;
++				switch(i)
++				{
++					/* Ignore RNR sensors because they might be removed */
++					case THERMAL_LM75_T1:
++					case THERMAL_LM75_T2:
++					case THERMAL_LM75_T4:
++					case THERMAL_LM75_T5:
++					case THERMAL_LM75_T6:
++					case THERMAL_LM75_T7:
++						continue;
++						break;
++					default:
++						dev_err(&client->dev, "Failed to convert temperature read from (%s)\n", thermal_sensor_path[i]);
++						goto exit;
++				}
+ 			}
+ 		}
+ 		else {
+-			dev_dbg(&client->dev, "Failed to read temperature from (%s)\n", thermal_sensor_path[i]);
++			dev_err(&client->dev, "Failed to read temperature from (%s)\n", thermal_sensor_path[i]);
+ 			goto exit;
+ 		}
+ 	}
+ 
+-	data->valid = 1;
++	data->temp_is_valid = 1;
+ 
+ exit:
+ 	return data;
+@@ -1030,7 +1045,7 @@ static int fan_speed_ctrl_routine(void *arg)
+ 		 * 1. Invalid fan data
+ 		 * 2. Any fan is in failed state
+ 		 */
+-		if (!data->valid || is_any_fan_failed(data)) {
++		if (!data->temp_is_valid || is_any_fan_failed(data)) {
+ 			fan_set_duty_cycle_to_cpld(client, FAN_DUTY_CYCLE_MAX_CPLD_VAL);
+ 			continue;
+ 		}
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-qoriq_4.1.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_4.1.bbappend
@@ -50,6 +50,7 @@ SRC_URI_append_t600 += "file://${MACHINE}/patches/0002-4.1-Chage-to-fit-T600-NOR
                         file://${MACHINE}/patches/0041-Add-PIU-scan-mutex.-Application-must-use-this-mutex-.patch  \
                         file://${MACHINE}/patches/0042-ACCTON-858-Main-signal-is-down-after-PIU-reseat.patch       \
                         file://${MACHINE}/patches/0043-ACCTON-996-Too-many-open-files-in-system.patch \
+                        file://${MACHINE}/patches/0044-Fan-speed-changes-to-max-automatically.patch \
                        "
 
 KERNEL_DEFCONFIG  = "${WORKDIR}/${MACHINE}/kconfig/${MACHINE}_config"


### PR DESCRIPTION
 Root casue:
  FAN driver uses Linux string conversion API to get temperature string. When this
  API return error, the temperature value is wrong, it casues FAN driver sets
  FAN to full speed.
 Solution:
  1. Buffer clear before read temperature, otherwise it will keep last value and cause kstrtoint parser error.
  2. separate the check flag, valid and temp-is-valid, for FAN updater and temperature updater.