### PR TITLE
update fan driver for support T650 and T600

### DIFF
--- a/recipes-kernel/linux/files/pyro/t650/dts/t650.dtsi
+++ b/recipes-kernel/linux/files/pyro/t650/dts/t650.dtsi
@@ -214,12 +214,12 @@
 					reg = <0x4>;
 
 					eeprom@52 {
-						compatible = "at24,24c256";
+						compatible = "at24,24c64";
 						reg = <0x52>;
 					};
 
 					eeprom@53 {
-						compatible = "at24,24c256";
+						compatible = "at24,24c64";
 						reg = <0x53>;
 					};
 				};
@@ -232,6 +232,64 @@
 					t600_fan@61 {
 						compatible = "t600_fan";
 						reg = <0x61>;
+					};
+
+					pca9548@75 {
+						compatible = "nxp,pca9548";
+						reg = <0x75>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+						i2c@1 {
+							#address-cells = <1>;
+							#size-cells = <0>;
+							reg = <0x1>;
+
+							eeprom@56 {
+								compatible = "at24,24c64";
+								reg = <0x56>;
+							};
+						};
+						i2c@2 {
+							#address-cells = <1>;
+							#size-cells = <0>;
+							reg = <0x2>;
+
+							eeprom@56 {
+								compatible = "at24,24c64";
+								reg = <0x56>;
+							};
+						};
+						i2c@3 {
+							#address-cells = <1>;
+							#size-cells = <0>;
+							reg = <0x3>;
+
+							eeprom@56 {
+								compatible = "at24,24c64";
+								reg = <0x56>;
+							};
+						};
+						i2c@4 {
+							#address-cells = <1>;
+							#size-cells = <0>;
+							reg = <0x4>;
+
+							eeprom@56 {
+								compatible = "at24,24c64";
+								reg = <0x56>;
+							};
+						};
+						i2c@5 {
+							#address-cells = <1>;
+							#size-cells = <0>;
+							reg = <0x5>;
+
+							eeprom@56 {
+								compatible = "at24,24c64";
+								reg = <0x56>;
+							};
+						};
 					};
 				};
 

--- a/recipes-kernel/linux/files/t650/patches/0047-Modify-sysfs-interface-from-i2c-device-to-hwmon-clas.patch
+++ b/recipes-kernel/linux/files/t650/patches/0047-Modify-sysfs-interface-from-i2c-device-to-hwmon-clas.patch
@@ -1,0 +1,51 @@
+From 5710eef0dbb6af461e37df34937e1d233752d798 Mon Sep 17 00:00:00 2001
+From: roy_chuang <roy_chuang@edge.core.com>
+Date: Thu, 12 Sep 2019 11:11:03 +0800
+Subject: [PATCH] Modify sysfs interface from i2c device to hwmon class.
+
+1. Both of T600 & T650 support this interface.
+---
+ drivers/hwmon/accton_t600_fan.c | 21 ++++-----------------
+ 1 file changed, 4 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/hwmon/accton_t600_fan.c b/drivers/hwmon/accton_t600_fan.c
+index 0475575..4032982 100755
+--- a/drivers/hwmon/accton_t600_fan.c
++++ b/drivers/hwmon/accton_t600_fan.c
+@@ -69,29 +69,16 @@ enum thermal_id
+     NUM_OF_THERMAL_SENSOR
+ };
+ 
+-#if 1 /* Roy Chuang Mark Begin 2018/9/5, reason: */
+ char *thermal_sensor_path[NUM_OF_THERMAL_SENSOR] = {
+-"/sys/bus/i2c/devices/20-0049/hwmon/hwmon8/temp1_input", /* RNR sensor from PIU1 */
+-"/sys/bus/i2c/devices/21-0049/hwmon/hwmon9/temp1_input", /* RNR sensor from PIU2 */
+-"/sys/bus/i2c/devices/31-0048/hwmon/hwmon10/temp1_input",
++"/sys/class/hwmon/hwmon8/temp1_input", /* RNR sensor from PIU1 */
++"/sys/class/hwmon/hwmon9/temp1_input", /* RNR sensor from PIU2 */
++"/sys/class/hwmon/hwmon10/temp1_input",
+ "none_temp1_input",    /* skip */
+ "none_temp1_input",    /* skip */
+ "none_temp1_input",    /* skip */
+ "none_temp1_input",    /* skip */
+-"/sys/bus/i2c/devices/6-001a/hwmon/hwmon2/temp1_input"
++"/sys/class/hwmon/hwmon2/temp1_input"
+ };
+-#else /* simulation */
+-char *thermal_sensor_path[NUM_OF_THERMAL_SENSOR] = {
+-"/sys/bus/i2c/devices/10-0061/temp0_input",
+-"/sys/bus/i2c/devices/10-0061/temp1_input",
+-"/sys/bus/i2c/devices/10-0061/temp2_input",
+-"/sys/bus/i2c/devices/10-0061/temp3_input",
+-"/sys/bus/i2c/devices/10-0061/temp4_input",
+-"/sys/bus/i2c/devices/10-0061/temp5_input",
+-"/sys/bus/i2c/devices/10-0061/temp6_input",
+-"/sys/bus/i2c/devices/10-0061/temp7_input",
+-};
+-#endif /* Roy Chuang Mark End */
+ 
+ typedef struct fan_ctrl_policy {
+    int cpld_val;
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-qoriq_4.1.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_4.1.bbappend
@@ -104,6 +104,7 @@ SRC_URI_append_t650 += "file://${MACHINE}/patches/0002-4.1-Chage-to-fit-T650-NOR
                         file://${MACHINE}/patches/0044-4.1-Fan-speed-changes-to-max-automatically.patch            \
                         file://${MACHINE}/patches/0045-modify-code-for-the-new-hardware-device-T650.patch          \
                         file://${MACHINE}/patches/0046-support-QSFPDD-EEPROM.patch                                 \
+                        file://${MACHINE}/patches/0047-Modify-sysfs-interface-from-i2c-device-to-hwmon-clas.patch  \
                        "
 
 KERNEL_DEFCONFIG  = "${WORKDIR}/${MACHINE}/kconfig/${MACHINE}_config"


### PR DESCRIPTION
Hardware design has a little bit difference between T600 and T650,
1. we change the DTS to support new FAN eeprom
2. we change the path of sysfs from bus/i2c/ to class/ in the fan driver, it is common and hardware independence.