### PR TITLE
add mbar, msync, isync in write io procedure for memory barrier in po…

### DIFF
--- a/recipes-kernel/linux/files/t600/patches/0053-Change-the-code-from-isync-to-asm-volatile-for-memor.patch
+++ b/recipes-kernel/linux/files/t600/patches/0053-Change-the-code-from-isync-to-asm-volatile-for-memor.patch
@@ -1,0 +1,31 @@
+From 96c45f3d0b12da5ed5464e06123c108e294c1b18 Mon Sep 17 00:00:00 2001
+From: aken_liu <aken_liu@accton.com.tw>
+Date: Mon, 28 Oct 2019 11:15:56 +0800
+Subject: [PATCH] Change the code from isync() to asm volatile() for memory
+ barrier in PowerPC.
+
+---
+ drivers/misc/accton_t600_fj_mdec.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/misc/accton_t600_fj_mdec.c b/drivers/misc/accton_t600_fj_mdec.c
+index c095965..0e29abf 100755
+--- a/drivers/misc/accton_t600_fj_mdec.c
++++ b/drivers/misc/accton_t600_fj_mdec.c
+@@ -190,7 +190,12 @@ static void t600_fj_mdec_write32(u32 value, void *addr)
+ 
+     mutex_lock(&io_lock);
+     iowrite32(data, addr);
+-    isync();
++
++    /* According to FJ's suggestion, we change the code from isync() to asm volatile() for memory barrier in PowerPC.
++     */
++    asm volatile("mbar 0" : : : "memory");
++    asm volatile("msync" : : : "memory");
++    asm volatile("isync" : : : "memory");
+     mutex_unlock(&io_lock);
+ }
+ 
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/files/t650/patches/0053-Change-the-code-from-isync-to-asm-volatile-for-memor.patch
+++ b/recipes-kernel/linux/files/t650/patches/0053-Change-the-code-from-isync-to-asm-volatile-for-memor.patch
@@ -1,0 +1,31 @@
+From 96c45f3d0b12da5ed5464e06123c108e294c1b18 Mon Sep 17 00:00:00 2001
+From: aken_liu <aken_liu@accton.com.tw>
+Date: Mon, 28 Oct 2019 11:15:56 +0800
+Subject: [PATCH] Change the code from isync() to asm volatile() for memory
+ barrier in PowerPC.
+
+---
+ drivers/misc/accton_t600_fj_mdec.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/misc/accton_t600_fj_mdec.c b/drivers/misc/accton_t600_fj_mdec.c
+index c095965..0e29abf 100755
+--- a/drivers/misc/accton_t600_fj_mdec.c
++++ b/drivers/misc/accton_t600_fj_mdec.c
+@@ -190,7 +190,12 @@ static void t600_fj_mdec_write32(u32 value, void *addr)
+ 
+     mutex_lock(&io_lock);
+     iowrite32(data, addr);
+-    isync();
++
++    /* According to FJ's suggestion, we change the code from isync() to asm volatile() for memory barrier in PowerPC.
++     */
++    asm volatile("mbar 0" : : : "memory");
++    asm volatile("msync" : : : "memory");
++    asm volatile("isync" : : : "memory");
+     mutex_unlock(&io_lock);
+ }
+ 
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-qoriq_4.1.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_4.1.bbappend
@@ -60,6 +60,7 @@ SRC_URI_append_t600 += "file://${MACHINE}/patches/0002-4.1-Chage-to-fit-T600-NOR
                         file://${MACHINE}/patches/0050-Modify-default-time-interval-from-3-to-6-seconds.patch      \
                         file://${MACHINE}/patches/0051-Modify-FAN-speed-gradullay-algorithm.-Don-t-check-te.patch  \
                         file://${MACHINE}/patches/0052-Modify-FAN-algorithm.-Don-t-check-FAN-status-in-ther.patch  \
+                        file://${MACHINE}/patches/0053-Change-the-code-from-isync-to-asm-volatile-for-memor.patch  \
                        "
 
 SRC_URI_append_t650 += "file://${MACHINE}/patches/0002-4.1-Chage-to-fit-T650-NOR-flash-partition.patch \
@@ -116,6 +117,7 @@ SRC_URI_append_t650 += "file://${MACHINE}/patches/0002-4.1-Chage-to-fit-T650-NOR
                         file://${MACHINE}/patches/0050-Modify-default-time-interval-from-3-to-6-seconds.patch      \
                         file://${MACHINE}/patches/0051-Modify-FAN-speed-gradullay-algorithm.-Don-t-check-te.patch  \
                         file://${MACHINE}/patches/0052-Modify-FAN-algorithm.-Don-t-check-FAN-status-in-ther.patch  \
+                        file://${MACHINE}/patches/0053-Change-the-code-from-isync-to-asm-volatile-for-memor.patch  \
                        "
 
 KERNEL_DEFCONFIG  = "${WORKDIR}/${MACHINE}/kconfig/${MACHINE}_config"


### PR DESCRIPTION
…werpc

Information from FJ:
I have heard that there is a possibility that “Read” and “Write” instruction may be reversed in PowerPC.
Fujitsu PowerPC products prevent this problem in the following ways.
1. Write IO.
2. asm volatile("mbar 0" : : : "memory");
3. asm volatile("msync" : : : "memory");
4. asm volatile("isync" : : : "memory");