### PR TITLE
deliver_missed_correction_to_patch_0040-4.1

### DIFF
--- a/recipes-kernel/linux/files/t600/patches/0040-4.1-ACCTON-727-fix_incomplete_patch-dpa-tx-err-hand.patch
+++ b/recipes-kernel/linux/files/t600/patches/0040-4.1-ACCTON-727-fix_incomplete_patch-dpa-tx-err-hand.patch
@@ -22,7 +22,7 @@ index 9896137..3c11c59 100644
 +
 +	priv = netdev_priv(net_dev);
 +	/* Non-migratable context, safe to use __this_cpu_ptr */
-+	percpu_priv = __this_cpu_ptr(priv->percpu_priv);
++	percpu_priv = this_cpu_ptr(priv->percpu_priv);
 +	percpu_stats = &percpu_priv->stats;
    
  /* modify by peter, for BCM management tag*/

--- a/recipes-kernel/linux/linux-qoriq_4.1.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_4.1.bbappend
@@ -183,4 +183,4 @@ do_deploy_prepend() {
     done
 }
 
-PR := "${PR}.7"
+PR := "${PR}.8"


### PR DESCRIPTION
This change was made by James Dang in our bitbucket, but the version on Github has never been updated.  I am not sure how the 4.1 kernel has been building previously, because it failed for me without this change after yesterday's delivery.