### PR TITLE
updates_to_ata_idle_and_reset_type_map_and_mdio_bus_driver

### DIFF
--- a/recipes-kernel/linux/files/t700/patches/0054-v2-Send-ATA_CMD_IDLEIMMEDIATE-command-to-sda-when-sy.patch
+++ b/recipes-kernel/linux/files/t700/patches/0054-v2-Send-ATA_CMD_IDLEIMMEDIATE-command-to-sda-when-sy.patch
@@ -3,6 +3,7 @@ From: roy_chuang <roy_chuang@edge.core.com>
 Date: Fri, 1 Nov 2019 16:49:22 +0800
 Subject: [PATCH 1/2] Send ATA_CMD_IDLEIMMEDIATE command to sda when system
  reset. Reference: patch from ACCTON-1066.
+ Note: Modified by peter.bugni@Fujitsu.com, for idle check change. Jan, 2020.
 
 ---
  drivers/hwmon/accton_t600_cpld.c | 53 +++++++++++++++++++++++++++++++++++++++-
@@ -12,7 +13,7 @@ diff --git a/drivers/hwmon/accton_t600_cpld.c b/drivers/hwmon/accton_t600_cpld.c
 index 5dbe8a3..0823ded 100755
 --- a/drivers/hwmon/accton_t600_cpld.c
 +++ b/drivers/hwmon/accton_t600_cpld.c
-@@ -32,6 +32,16 @@
+@@ -32,6 +32,17 @@
  #include <linux/sysfs.h>
  #include <linux/slab.h>
  #include <linux/delay.h>
@@ -26,13 +27,23 @@ index 5dbe8a3..0823ded 100755
 +#include <asm/uaccess.h>
 +#include <asm-generic/ioctl.h>
 +#include <uapi/asm/ioctl.h>
++#include <sysdev/fsl_soc.h>
  
  #define DRVNAME "t600_cpld"
  #define I2C_RW_RETRY_COUNT          10
-@@ -387,6 +397,40 @@ exit:
+@@ -49,6 +60,8 @@
+ #define RESET_CONTROL_REG           0x26
+ #define OTP_RECORD_REG              0x27
+ #define PIU_THERMAL_CONTROL_REG     0x19
++#define CER_IDLE_LOOP_CNT           0x1000
++#define CER_IDLE_LOOP_DELAY         1000
+ 
+ struct t600_cpld_data {
+     struct device      *hwmon_dev;
+@@ -387,6 +400,55 @@ exit:
      return status;
  }
- 
+
 +/*!
 +** @brief Set the disk to IDLE. Will rewrite IDLE command until the SATA CER
 +**        register is 0x0. JIRA ACCTON-1066
@@ -41,25 +52,40 @@ index 5dbe8a3..0823ded 100755
 +    mm_segment_t old_fs;
 +    int fd;
 +    int rc;
++    int loopNdx;
 +    unsigned char args[4] = {0, 0, 0, 0};
++    volatile unsigned long *sata_cer_reg = 0;
 +
 +    old_fs = get_fs();
 +    set_fs(KERNEL_DS);
 +
 +    fd = sys_open(devicename, O_RDONLY, 0);
 +    if (fd >= 0) {
++        sata_cer_reg = (volatile unsigned long*)ioremap_nocache(
++                        (get_immrbase() | 0x220018), sizeof(unsigned long));
 +        printk (KERN_ERR "%s(): Sending IDLE IMMEDIATE to %s device.\n",
-+            __FUNCTION__, devicename);
++                 __FUNCTION__, devicename);
 +        args[0] = ATA_CMD_IDLEIMMEDIATE;
-+        rc = sys_ioctl(fd, HDIO_DRIVE_CMD, (unsigned long)args);
++        rc = sys_ioctl(fd, HDIO_DRIVE_CMD, (long unsigned int)args);
 +        sys_close(fd);
-+
-+        if (rc != 0) {
-+            printk (KERN_ERR "%s(): IDLE for %s device failed rc %d.\n",
-+                __FUNCTION__, devicename, rc);
++        if (rc == 0) {
++            if ( sata_cer_reg != 0 ) {
++                for ( loopNdx=0; loopNdx<CER_IDLE_LOOP_CNT; loopNdx++ ) {
++                    if ( 0x0 == *sata_cer_reg ) {
++                        printk (KERN_ERR "%s:%s():%d: Successful force %s into IDLE mode!.\n",
++                                                 __FILE__, __FUNCTION__, __LINE__, devicename);
++                        break;
++                    }
++                    udelay(CER_IDLE_LOOP_DELAY);
++                }
++                if (CER_IDLE_LOOP_CNT == loopNdx) {
++                    printk (KERN_ERR "%s:%s():%d: ERROR - Failed to force %s into IDLE mode.\n",
++                                                   __FILE__, __FUNCTION__, __LINE__, devicename);
++                }
++            }
 +        } else {
-+            printk (KERN_ERR "%s(): IDLE for %s device OK rc %d.\n",
-+                __FUNCTION__, devicename, rc);
++            printk (KERN_ERR "%s(): IDLE ioctl for %s device failed rc %d.\n",
++                         __FUNCTION__, devicename, rc);
 +        }
 +    } else {
 +        printk (KERN_ERR "%s:%s():%d: ERROR - Failed to open the file %s device. \n",
@@ -70,7 +96,7 @@ index 5dbe8a3..0823ded 100755
  
  int t600_reset(int reset_type)
  {
-@@ -400,12 +444,19 @@ int t600_reset(int reset_type)
+@@ -400,12 +462,19 @@ int t600_reset(int reset_type)
  		return -1;
  	}
  

--- a/recipes-kernel/linux/files/t700/patches/0056-mdio-bus-find-by-name.patch
+++ b/recipes-kernel/linux/files/t700/patches/0056-mdio-bus-find-by-name.patch
@@ -1,0 +1,42 @@
+diff --git a/drivers/net/phy/mdio_bus.c b/drivers/net/phy/mdio_bus.c
+index 9c86de2..0397fb5 100644
+--- a/drivers/net/phy/mdio_bus.c
++++ b/drivers/net/phy/mdio_bus.c
+@@ -371,6 +371,34 @@ struct phy_device *mdiobus_scan(struct mii_bus *bus, int addr)
+ }
+ EXPORT_SYMBOL(mdiobus_scan);
+ 
++static int mdiobus_match_name( struct device * dev, void * data )
++{
++    const char * name = data;
++
++    return sysfs_streq( name, dev_name( dev ) );
++}
++
++/**
++ * mdiobus_find_by_name - Convenience function for retrieving an mii_bus pointer
++ *                        by name
++ * @name: name of the bus being searched for
++ */
++struct mii_bus * mdiobus_find_by_name( char * name )
++{
++    struct device * dev;
++
++    /* search devices registered for with the mdio_bus_class using the device
++       name as the matching criteria */
++    dev = class_find_device( &mdio_bus_class,
++                             NULL,
++                             (void *)name,
++                             mdiobus_match_name );
++
++    /* return the mii_bus pointer or NULL if none was found */
++    return dev ? container_of( dev, struct mii_bus, dev ) : NULL;
++}
++EXPORT_SYMBOL( mdiobus_find_by_name );
++
+ /**
+  * mdiobus_read - Convenience function for reading a given MII mgmt register
+  * @bus: the mii_bus struct
+-- 
+1.8.3.1
+

--- a/recipes-kernel/linux/files/t700/patches/0057-Remap_fnc_reset_types_to_standardize.patch
+++ b/recipes-kernel/linux/files/t700/patches/0057-Remap_fnc_reset_types_to_standardize.patch
@@ -1,0 +1,25 @@
+diff -Naur a/arch/powerpc/sysdev/fsl_soc.c b/arch/powerpc/sysdev/fsl_soc.c
+--- a/arch/powerpc/sysdev/fsl_soc.c	2020-01-14 13:43:17.985946212 -0600
++++ b/arch/powerpc/sysdev/fsl_soc.c	2020-01-14 13:48:48.368788752 -0600
+@@ -195,7 +195,7 @@
+ /*!
+ ** @brief Invoked at startup. Will allocate and map registers used during reset.
+ **        linux reset     -> FNC Warm reset
+-**        linux halt      -> FNC Hard Reset
++**        linux halt      -> FNC Power off
+ **        linux power off -> FNC Hard Reset
+ */
+ extern void fss2_reset_warm(char *cmd);
+@@ -204,9 +204,9 @@
+ 
+ static int __init setup_finity_reset(void)
+ {
+-    ppc_md.restart    = fss2_reset_warm;         // Warm (default)
+-    pm_power_off      = fss2_reset_power_off;    // Hard
+-    ppc_md.halt       = fss2_reset_hard;         // Hard
++    ppc_md.restart    = fss2_reset_warm;         // Warm (reboot) (default)
++    pm_power_off      = fss2_reset_hard;         // Hard reset
++    ppc_md.halt       = fss2_reset_power_off;    // Power off
+ 
+ 	return 0;
+ }

--- a/recipes-kernel/linux/linux-qoriq_4.1.bbappend
+++ b/recipes-kernel/linux/linux-qoriq_4.1.bbappend
@@ -186,8 +186,10 @@ SRC_URI_append_t700 += "file://${MACHINE}/patches/0002-4.1-Chage-to-fit-T650-NOR
                         file://${MACHINE}/patches/0052-Modify-FAN-algorithm.-Don-t-check-FAN-status-in-ther.patch  \
                         file://${MACHINE}/patches/0053-Change-the-code-from-isync-to-asm-volatile-for-memor.patch  \
                         file://${MACHINE}/patches/0053-4.1-T600-3041-FIPS-disable-print-of-keys.patch              \
-                        file://${MACHINE}/patches/0054-Send-ATA_CMD_IDLEIMMEDIATE-command-to-sda-when-syste.patch  \
+                        file://${MACHINE}/patches/0054-v2-Send-ATA_CMD_IDLEIMMEDIATE-command-to-sda-when-sy.patch  \
                         file://${MACHINE}/patches/0055-Fix-issue-ACCTON-947.patch                                  \
+                        file://${MACHINE}/patches/0056-mdio-bus-find-by-name.patch                                 \
+                        file://${MACHINE}/patches/0057-Remap_fnc_reset_types_to_standardize.patch                  \
                        "
 
 
@@ -248,4 +250,4 @@ do_deploy_prepend() {
     done
 }
 
-PR := "${PR}.9"
+PR := "${PR}.10"


### PR DESCRIPTION
Incorporate three changes from FNC.  Bring patches up to date with FNC build.
1) Patch 0057 changes the mapping of the reset type names used to achieve warm, hard, and power down type resets.  This allows a FNC-standard mapping to the ps_shutdown reset types.
2) Patch 0056 adds functionality to the mdio bus driver that is used by FNC mii access driver.
3) Patch 0054-v2,  replaces patch 0054, incorporating a fix to the ATA-IDLE-Immediate logic used during reset .