### PR TITLE
reverse_reset_remap_of_0060

### DIFF
--- a/recipes-kernel/linux/files/t700/patches/0060-Fix-hardware-reset-and-blade-eeprom-issues.patch
+++ b/recipes-kernel/linux/files/t700/patches/0060-Fix-hardware-reset-and-blade-eeprom-issues.patch
@@ -48,7 +48,7 @@ index 2d55be6..09a240f 100755
  {
  	int status;
 -	status = fss2_reset(COLD_RESTART);
-+	status = fss2_reset(POWER_OFF);
++	status = fss2_reset(COLD_RESTART);  /* fnc hard */
  	return ;
  }
  
@@ -65,7 +65,7 @@ index 2d55be6..09a240f 100755
 -    status = fss2_reset(POWER_OFF);
 -    return ;
 +	int status;
-+	status = fss2_reset(COLD_RESTART);
++	status = fss2_reset(POWER_OFF);  /* fnc power off */
 +	return ;
  }
  


### PR DESCRIPTION
Change patch 0060 to leave the mapping of linux reset types unchanged.